### PR TITLE
remove 'remove' call filter

### DIFF
--- a/maybe/syscall_filters.py
+++ b/maybe/syscall_filters.py
@@ -136,12 +136,6 @@ SyscallFilter = namedtuple("SyscallFilter", ["name", "signature", "format", "sub
 SYSCALL_FILTERS = [
 # Delete
 SyscallFilter(
-    name="remove",
-    signature=("int", (("const char *", "pathname"),)),
-    format=lambda args: format_delete(args[0]),
-    substitute=return_zero
-),
-SyscallFilter(
     name="unlink",
     signature=("int", (("const char *", "pathname"),)),
     format=lambda args: format_delete(args[0]),


### PR DESCRIPTION
According to our discussion on #15 , `remove` being a library call ( `(3)` ), it should not be under `SYSCALL_FILTERS`